### PR TITLE
Nmt block results fix

### DIFF
--- a/cmd/token-cli/cmd/chain.go
+++ b/cmd/token-cli/cmd/chain.go
@@ -90,7 +90,7 @@ var watchChainCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			if lastAccepted-uint64(*acceptedWindow) > startBlock {
+			if lastAccepted > uint64(*acceptedWindow) && lastAccepted-uint64(*acceptedWindow) > startBlock {
 				return fmt.Errorf("start block is too old")
 			}
 		}

--- a/cmd/token-cli/cmd/chain.go
+++ b/cmd/token-cli/cmd/chain.go
@@ -67,6 +67,7 @@ var chainInfoCmd = &cobra.Command{
 var watchChainCmd = &cobra.Command{
 	Use: "watch",
 	RunE: func(_ *cobra.Command, args []string) error {
+		ctx := context.Background()
 		pastBlocks, err := handler.Root().PromptBool("streaming from past blocks?")
 		if err != nil {
 			return err
@@ -76,6 +77,21 @@ var watchChainCmd = &cobra.Command{
 			startBlock, err = handler.Root().PromptUint64("start block")
 			if err != nil {
 				return err
+			}
+			_, _, _, cli, _, bcli, err := handler.DefaultActor()
+			if err != nil {
+				return err
+			}
+			_, lastAccepted, _, err := cli.Accepted(ctx)
+			if err != nil {
+				return err
+			}
+			acceptedWindow, err := bcli.GetAcceptedBlockWindow(ctx)
+			if err != nil {
+				return err
+			}
+			if lastAccepted-uint64(*acceptedWindow) > startBlock {
+				return fmt.Errorf("start block is too old")
 			}
 		}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -233,3 +233,7 @@ func (*Controller) Shutdown(context.Context) error {
 	// close any databases your provided.
 	return nil
 }
+
+func (c *Controller) GetAcceptedBlockWindow() int {
+	return c.config.GetAcceptedBlockWindow()
+}

--- a/rpc/dependencies.go
+++ b/rpc/dependencies.go
@@ -21,6 +21,7 @@ type Controller interface {
 	GetBalanceFromState(context.Context, ed25519.PublicKey, ids.ID) (uint64, error)
 	GetLoanFromState(context.Context, ids.ID, ids.ID) (uint64, error)
 	UnitPrices(ctx context.Context) (chain.Dimensions, error)
+	GetAcceptedBlockWindow() int
 	Submit(
 		ctx context.Context,
 		verifySig bool,

--- a/rpc/jsonrpc_client.go
+++ b/rpc/jsonrpc_client.go
@@ -260,6 +260,17 @@ func (cli *JSONRPCClient) GetCommitmentBlocks(
 	return resp, err
 }
 
+func (cli *JSONRPCClient) GetAcceptedBlockWindow(ctx context.Context) (*int, error) {
+	resp := new(int)
+	err := cli.requester.SendRequest(
+		ctx,
+		"getAcceptedBlockWindow",
+		nil,
+		resp,
+	)
+	return resp, err
+}
+
 // TODO add more methods
 func (cli *JSONRPCClient) WaitForBalance(
 	ctx context.Context,

--- a/rpc/jsonrpc_server.go
+++ b/rpc/jsonrpc_server.go
@@ -799,3 +799,8 @@ func (j *JSONRPCServer) ServerParser(ctx context.Context, networkId uint32, chai
 	// The only thing this is using is the ActionRegistry and AuthRegistry so this should be fine
 	return &Parser{networkId, chainId, g}
 }
+
+func (j *JSONRPCServer) GetAcceptedBlockWindow(req *http.Request, _ *struct{}, reply *int) error {
+	*reply = j.c.GetAcceptedBlockWindow()
+	return nil
+}


### PR DESCRIPTION
Added checks in chain watch while backward streaming.

Things to note when attempting to stream `block.Results`

- `block.Results` of last `GetAcceptedBlockWindow()` are stored to the disk along with `statefulblk` and `feemanager`
- When the expiry height has been reached, `block.Results` along with `statefulblk` and `block.feemanager` are cleared from disk.
- SEQ currently uses 768 as AcceptedBlockWindow.