### PR TITLE
Arcadia rollup

### DIFF
--- a/actions/errors.go
+++ b/actions/errors.go
@@ -14,4 +14,5 @@ var (
 	ErrNameSpaceNotRegistered          = errors.New("namespace not registered")
 	ErrNotAuthorized                   = errors.New("not authorized")
 	ErrNameSpaceAlreadyRegistered      = errors.New("namespace already registered")
+	ErrExitEpochSmallerThanStartEpoch  = errors.New("exit epoch is smaller than start epoch")
 )

--- a/actions/rollup_register.go
+++ b/actions/rollup_register.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"slices"
 
 	hactions "github.com/AnomalyFi/hypersdk/actions"
 	"github.com/AnomalyFi/hypersdk/chain"
@@ -20,7 +19,7 @@ var _ chain.Action = (*RollupRegistration)(nil)
 
 const (
 	CreateRollup = iota
-	DeleteRollup
+	ExitRollup
 	UpdateRollup
 )
 
@@ -45,6 +44,8 @@ func (*RollupRegistration) StateKeysMaxChunks() []uint16 {
 	return []uint16{hactions.RollupInfoChunks, hactions.RollupRegistryChunks}
 }
 
+// TODO: this action needs to be managed by DAO to manage deletions since we are not deleting any namespace from storage
+// but only by marking them as regsitered or exited
 func (r *RollupRegistration) Execute(
 	ctx context.Context,
 	rules chain.Rules,
@@ -69,17 +70,18 @@ func (r *RollupRegistration) Execute(
 
 	switch r.OpCode {
 	case CreateRollup:
-		if r.Info.StartEpoch < Epoch(hght, rules.GetEpochLength())+2 {
-			return nil, fmt.Errorf("epoch number is not valid, minimum: %d, actual: %d", Epoch(hght, rules.GetEpochLength())+2, r.Info.StartEpoch)
-		}
 		if contains(namespaces, r.Namespace) {
 			return nil, ErrNameSpaceAlreadyRegistered
+		}
+		if r.Info.StartEpoch < Epoch(hght, rules.GetEpochLength())+2 || r.Info.ExitEpoch != 0 {
+			return nil, fmt.Errorf("epoch number is not valid, minimum: %d, actual: %d, exit: %d", Epoch(hght, rules.GetEpochLength())+2, r.Info.StartEpoch, r.Info.ExitEpoch)
 		}
 		namespaces = append(namespaces, r.Namespace)
 		if err := storage.SetRollupInfo(ctx, mu, r.Namespace, &r.Info); err != nil {
 			return nil, fmt.Errorf("unable to set rollup info(CREATE): %s", err.Error())
 		}
 	case UpdateRollup:
+		// only allow modifing informations that are not related to ExitEpoch or StartEpoch
 		if err := authorizationChecks(ctx, actor, namespaces, r.Namespace, mu); err != nil {
 			return nil, fmt.Errorf("authorization failed(UPDATE): %s", err.Error())
 		}
@@ -88,32 +90,22 @@ func (r *RollupRegistration) Execute(
 		if err != nil {
 			return nil, fmt.Errorf("unable to get existing rollup info(UPDATE): %s", err.Error())
 		}
-		if r.Info.StartEpoch != rollupInfoExists.StartEpoch && r.Info.StartEpoch < Epoch(hght, rules.GetEpochLength())+2 {
-			return nil, fmt.Errorf("(UPDATE)epoch number is not valid, minimum: %d, actual: %d, prev: %d", Epoch(hght, rules.GetEpochLength())+2, r.Info.StartEpoch, rollupInfoExists.StartEpoch)
+		if rollupInfoExists.ExitEpoch != r.Info.ExitEpoch || rollupInfoExists.StartEpoch != r.Info.StartEpoch {
+			return nil, fmt.Errorf("disallowed tamper for exit epoch & start epoch")
 		}
 
 		if err := storage.SetRollupInfo(ctx, mu, r.Namespace, &r.Info); err != nil {
 			return nil, fmt.Errorf("unable to set rollup info(UPDATE): %s", err.Error())
 		}
-	case DeleteRollup:
+	case ExitRollup:
 		if err := authorizationChecks(ctx, actor, namespaces, r.Namespace, mu); err != nil {
-			return nil, fmt.Errorf("unable to set rollup info(DELETE): %s", err.Error())
+			return nil, fmt.Errorf("unable to set rollup info(EXIT): %s", err.Error())
 		}
-		if r.Info.StartEpoch < Epoch(hght, rules.GetEpochLength())+2 {
-			return nil, fmt.Errorf("(DELETE)epoch number is not valid, minimum: %d, actual: %d", Epoch(hght, rules.GetEpochLength())+2, r.Info.StartEpoch)
+		if r.Info.ExitEpoch < Epoch(hght, rules.GetEpochLength())+2 {
+			return nil, fmt.Errorf("(EXIT)epoch number is not valid, minimum: %d, actual: %d", Epoch(hght, rules.GetEpochLength())+2, r.Info.ExitEpoch)
 		}
-
-		nsIdx := -1
-		for i, ns := range namespaces {
-			if bytes.Equal(r.Namespace, ns) {
-				nsIdx = i
-				break
-			}
-		}
-		namespaces = slices.Delete(namespaces, nsIdx, nsIdx+1)
-
-		if err := storage.DelRollupInfo(ctx, mu, r.Namespace); err != nil {
-			return nil, err
+		if err := storage.SetRollupInfo(ctx, mu, r.Namespace, &r.Info); err != nil {
+			return nil, fmt.Errorf("unable to set rollup info(EXIT): %s", err.Error())
 		}
 	default:
 		return nil, fmt.Errorf("op code(%d) not supported", r.OpCode)

--- a/actions/rollup_register.go
+++ b/actions/rollup_register.go
@@ -109,6 +109,10 @@ func (r *RollupRegistration) Execute(
 		if r.Info.ExitEpoch < rollupInfoExists.StartEpoch || r.Info.ExitEpoch < Epoch(hght, rules.GetEpochLength())+2 {
 			return nil, fmt.Errorf("(EXIT)epoch number is not valid, minimum: %d, actual: %d, start: %d", Epoch(hght, rules.GetEpochLength())+2, r.Info.ExitEpoch, rollupInfoExists.StartEpoch)
 		}
+
+		// overwrite StartEpoch
+		r.Info.StartEpoch = rollupInfoExists.StartEpoch
+
 		if err := storage.SetRollupInfo(ctx, mu, r.Namespace, &r.Info); err != nil {
 			return nil, fmt.Errorf("unable to set rollup info(EXIT): %s", err.Error())
 		}

--- a/cmd/seq-cli/cmd/action.go
+++ b/cmd/seq-cli/cmd/action.go
@@ -123,7 +123,7 @@ var rollupCmd = &cobra.Command{
 			return err
 		}
 
-		op, err := handler.Root().PromptChoice("(0)create (1)delete (2)update", 3)
+		op, err := handler.Root().PromptChoice("(0)create (1)exit (2)update", 3)
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,9 @@ var rollupCmd = &cobra.Command{
 			FeeRecipient:        feeRecipient,
 			Namespace:           namespace,
 			AuthoritySEQAddress: feeRecipient,
-			StartEpoch:          e + 4,
+			SequencerPublicKey:  feeRecipient[:],
+			StartEpoch:          e + 10,
+			ExitEpoch:           0,
 		}
 		// Generate transaction
 		_, err = sendAndWait(ctx, []chain.Action{&actions.RollupRegistration{

--- a/controller/resolutions.go
+++ b/controller/resolutions.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/AnomalyFi/nodekit-seq/archiver"
 	"github.com/AnomalyFi/nodekit-seq/genesis"
+	rollupregistry "github.com/AnomalyFi/nodekit-seq/rollup_registry"
 	"github.com/AnomalyFi/nodekit-seq/storage"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/trace"
@@ -81,6 +82,10 @@ func (c *Controller) GetAcceptedBlockWindow() int {
 
 func (c *Controller) Archiver() *archiver.ORMArchiver {
 	return c.archiver
+}
+
+func (c *Controller) RollupRegistry() *rollupregistry.RollupRegistry {
+	return c.rollupRegistry
 }
 
 func (c *Controller) NetworkID() uint32 {

--- a/go.mod
+++ b/go.mod
@@ -173,4 +173,4 @@ require (
 
 // replace github.com/ava-labs/coreth => github.com/AnomalyFi/coreth v0.12.5-rc.6.1
 
-// replace github.com/AnomalyFi/hypersdk => ../hypersdk
+replace github.com/AnomalyFi/hypersdk => ../hypersdk

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/AnomalyFi/nodekit-seq
 go 1.21.12
 
 require (
-	github.com/AnomalyFi/hypersdk v0.9.7-arcadia.12
+	github.com/AnomalyFi/hypersdk v0.9.7-arcadia.13
 	github.com/ava-labs/avalanche-network-runner v1.7.4-rc.0
 	github.com/ava-labs/avalanchego v1.11.10
 	github.com/ethereum/go-ethereum v1.13.14
@@ -173,4 +173,4 @@ require (
 
 // replace github.com/ava-labs/coreth => github.com/AnomalyFi/coreth v0.12.5-rc.6.1
 
-replace github.com/AnomalyFi/hypersdk => ../hypersdk
+// replace github.com/AnomalyFi/hypersdk => ../hypersdk

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
-github.com/AnomalyFi/hypersdk v0.9.7-arcadia.12 h1:X5m2I249t4OMkCa2hAtB0VkDMcSFLtvl0QDBa3GR+AA=
-github.com/AnomalyFi/hypersdk v0.9.7-arcadia.12/go.mod h1:0Vj2PdwSFN7pat4Sno39IfmtOiv/gO9mxZXyRKnoKtI=
+github.com/AnomalyFi/hypersdk v0.9.7-arcadia.13 h1:jZJXZpW6gQkfH0draUp5fQLwCfKzRYhNLHDxz33ncOs=
+github.com/AnomalyFi/hypersdk v0.9.7-arcadia.13/go.mod h1:0Vj2PdwSFN7pat4Sno39IfmtOiv/gO9mxZXyRKnoKtI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
-github.com/AnomalyFi/hypersdk v0.9.7-arcadia.13 h1:jZJXZpW6gQkfH0draUp5fQLwCfKzRYhNLHDxz33ncOs=
-github.com/AnomalyFi/hypersdk v0.9.7-arcadia.13/go.mod h1:0Vj2PdwSFN7pat4Sno39IfmtOiv/gO9mxZXyRKnoKtI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=

--- a/rollup_registry/registry.go
+++ b/rollup_registry/registry.go
@@ -1,0 +1,57 @@
+package rollupregistry
+
+import (
+	"slices"
+	"sync"
+
+	hactions "github.com/AnomalyFi/hypersdk/actions"
+)
+
+type RollupRegistryOnlyRead interface {
+	RollupsValidAtEpoch(epoch uint64) []*hactions.RollupInfo
+}
+
+type RollupRegistryAllPerm interface {
+	RollupRegistryOnlyRead
+	Update(currentEpoch uint64, rollups []*hactions.RollupInfo)
+}
+
+var _ RollupRegistryAllPerm = (*RollupRegistry)(nil)
+
+type RollupRegistry struct {
+	rollups  []*hactions.RollupInfo
+	rollupsL sync.RWMutex
+}
+
+func NewRollupRegistr() *RollupRegistry {
+	return &RollupRegistry{
+		rollups: make([]*hactions.RollupInfo, 0),
+	}
+}
+
+func (r *RollupRegistry) RollupsValidAtEpoch(epoch uint64) []*hactions.RollupInfo {
+	r.rollupsL.RLock()
+	defer r.rollupsL.RUnlock()
+
+	ret := make([]*hactions.RollupInfo, 0)
+	for _, rollup := range r.rollups {
+		if !rollup.ValidAtEpoch(epoch) {
+			continue
+		}
+
+		ret = append(ret, rollup)
+	}
+
+	return ret
+}
+
+func (r *RollupRegistry) Update(currentEpoch uint64, rollups []*hactions.RollupInfo) {
+	r.rollupsL.Lock()
+	defer r.rollupsL.Unlock()
+
+	r.rollups = append(r.rollups, rollups...)
+	// remove exited rollups
+	r.rollups = slices.DeleteFunc(r.rollups, func(rollup *hactions.RollupInfo) bool {
+		return rollup.Exited(currentEpoch)
+	})
+}

--- a/rpc/dependencies.go
+++ b/rpc/dependencies.go
@@ -12,6 +12,7 @@ import (
 	"github.com/AnomalyFi/hypersdk/fees"
 	"github.com/AnomalyFi/nodekit-seq/archiver"
 	"github.com/AnomalyFi/nodekit-seq/genesis"
+	rollupregistry "github.com/AnomalyFi/nodekit-seq/rollup_registry"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/trace"
 	"github.com/ava-labs/avalanchego/utils/logging"
@@ -39,4 +40,5 @@ type Controller interface {
 	Logger() logging.Logger
 	// TODO: update this to only have read permission
 	Archiver() *archiver.ORMArchiver
+	RollupRegistry() *rollupregistry.RollupRegistry
 }

--- a/rpc/jsonrpc_client.go
+++ b/rpc/jsonrpc_client.go
@@ -300,6 +300,17 @@ func (cli *JSONRPCClient) GetAllRollupInfo(ctx context.Context) (*types.GetAllRo
 	return resp, err
 }
 
+func (cli *JSONRPCClient) GetValidRollupsAtEpoch(ctx context.Context, epoch uint64) (*types.GetRollupsInfoAtEpochReply, error) {
+	resp := new(types.GetRollupsInfoAtEpochReply)
+	err := cli.requester.SendRequest(
+		ctx,
+		"getValidRollupsAtEpoch",
+		types.GetRollupsInfoAtEpochArgs{Epoch: epoch},
+		resp,
+	)
+	return resp, err
+}
+
 func (cli *JSONRPCClient) GetEpochExits(ctx context.Context, epoch uint64) (*hactions.EpochExitInfo, error) {
 	resp := new(types.EpochExitsReply)
 	args := &types.EpochExitsArgs{Epoch: epoch}

--- a/rpc/jsonrpc_server.go
+++ b/rpc/jsonrpc_server.go
@@ -426,6 +426,12 @@ func (j *JSONRPCServer) GetAllRollupInfo(req *http.Request, _ *struct{}, reply *
 	return nil
 }
 
+func (j *JSONRPCServer) GetValidRollupsAtEpoch(req *http.Request, args *types.GetRollupsInfoAtEpochArgs, reply *types.GetRollupsInfoAtEpochReply) error {
+	registry := j.c.RollupRegistry()
+	reply.Rollups = registry.RollupsValidAtEpoch(args.Epoch)
+	return nil
+}
+
 var _ chain.Parser = (*ServerParser)(nil)
 
 type ServerParser struct {

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -135,9 +135,13 @@ find "${TMPDIR}"/avalanchego-"${VERSION}"
 # Make sure to replace this address with your own address
 # if you are starting your own devnet (otherwise anyone can access
 # funds using the included demo.pk)
+# total stake can allocate: 10000000000000000000, make sure it is below this or genesis won't load
 echo "creating allocations file"
 cat <<EOF > "${TMPDIR}"/allocations.json
-[{"address":"${ADDRESS}", "balance":10000000000000000000}]
+[
+  {"address":"${ADDRESS}", "balance":1000000000000000000},
+  {"address":"seq1qy94dndd0wzru9gvq3ayw52ngcd2fuhyptt58f4a3eppjzpx573qg9cr7sm", "balance":1000000000000000000}
+]
 EOF
 
 GENESIS_PATH=$2

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1111,7 +1111,7 @@ var _ = ginkgo.Describe("[Test]", func() {
 					StartEpoch:          currEpoch + 5,
 				},
 				Namespace: []byte("nkit2"),
-				OpCode:    actions.DeleteRollup,
+				OpCode:    actions.ExitRollup,
 			},
 		}
 

--- a/types/types.go
+++ b/types/types.go
@@ -247,3 +247,11 @@ type GetAllRollupInfoReply struct {
 	// epoch -> a list of rollup registration info
 	Info map[uint64][]hactions.RollupInfo `json:"info"`
 }
+
+type GetRollupsInfoAtEpochArgs struct {
+	Epoch uint64 `json:"epoch"`
+}
+
+type GetRollupsInfoAtEpochReply struct {
+	Rollups []*hactions.RollupInfo `json:"rollups"`
+}


### PR DESCRIPTION
This PR resolves the issue that prev implementation of rollup registration unable to capture the exact valid rollups at certain epoch.  Features included

- rollup registry, which accept rollup registeration info from a block and keep track of rollup registration epoch information(startEpoch and exitEpoch)
- we no longer remove any namespace from namespace registry in storage as that will be used on hypersdk level to determine if one namespace is exited/regsitered or not for one epoch
- EpochExit action is deprecated and shouldn't use
- rpc method for querying rollups at epoch n