### PR TITLE
Fix Typo: Change "registartion" to "registration" in Comments

### DIFF
--- a/actions/rollup_register.go
+++ b/actions/rollup_register.go
@@ -45,7 +45,7 @@ func (*RollupRegistration) StateKeysMaxChunks() []uint16 {
 }
 
 // TODO: this action needs to be managed by DAO to manage deletions since we are not deleting any namespace from storage
-// but only by marking them as regsitered or exited
+// but only by marking them as registered or exited
 func (r *RollupRegistration) Execute(
 	ctx context.Context,
 	rules chain.Rules,

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1029,7 +1029,7 @@ var _ = ginkgo.Describe("[Test]", func() {
 		_, startHeight, _, err := instances[0].cli.Accepted(ctx)
 		require.NoError(err)
 
-		// submit regsitration at startHeight
+		// submit registration at startHeight
 		currEpoch, err := instances[0].cli.GetCurrentEpoch()
 		require.NoError(err)
 		txActions := []chain.Action{&actions.RollupRegistration{


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the comments of two files:  
- actions/rollup_register.go  
- tests/e2e/e2e_test.go  

The word "registartion" has been replaced with the correct spelling "registration" to improve code readability and maintain consistency. No functional code changes were made.
