### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/seq-e2e-tests.yml
+++ b/.github/workflows/seq-e2e-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Install killall
         run: |
           sudo apt-get update

--- a/.github/workflows/seq-release.yml
+++ b/.github/workflows/seq-release.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run release') }}
     steps:
       - name: Git checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/seq-static-analysis.yml
+++ b/.github/workflows/seq-static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0